### PR TITLE
Use llvm-16 docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:bullseye-slim AS intermediate
+
+# Install dependencies
+RUN apt-get -qq update; \
+    apt-get install -qqy --no-install-recommends \
+        gnupg2 wget ca-certificates apt-transport-https \
+        autoconf automake cmake dpkg-dev file make patch libc6-dev libtool
+
+# Install LLVM
+RUN echo "deb https://apt.llvm.org/bullseye llvm-toolchain-bullseye-16 main" \
+        > /etc/apt/sources.list.d/llvm.list && \
+    wget -qO /etc/apt/trusted.gpg.d/llvm.asc \
+        https://apt.llvm.org/llvm-snapshot.gpg.key && \
+    apt-get -qq update && \
+    apt-get install -qqy -t llvm-toolchain-bullseye-16 clang-16 clang-tidy-16 clang-format-16 lld-16 libc++-16-dev libc++abi-16-dev && \
+    for f in /usr/lib/llvm-*/bin/*; do ln -sf "$f" /usr/bin; done && \
+    ln -sf clang /usr/bin/cc && \
+    ln -sf clang /usr/bin/c89 && \
+    ln -sf clang /usr/bin/c99 && \
+    ln -sf clang++ /usr/bin/c++ && \
+    ln -sf clang++ /usr/bin/g++ && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM intermediate as test
+
+COPY tests /tests
+
+RUN /tests/run.sh 16
+
+FROM intermediate as final

--- a/Makefile.clang
+++ b/Makefile.clang
@@ -3,7 +3,7 @@ LD := ld.lld-16
 OBJCOPY := llvm-objcopy-16
 CFLAGS := \
 	--target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs \
-	-fPIC -O3 -fno-builtin-printf -fno-builtin-memcmp -nostdinc -nostdlib -fvisibility=hidden -fdata-sections -ffunction-sections \
+	-fPIC -O2 -fno-builtin-printf -fno-builtin-memcmp -nostdinc -nostdlib -fvisibility=hidden -fdata-sections -ffunction-sections \
 	-I deps/secp256k1/src -I deps/secp256k1 -I deps/ckb-c-std-lib -I deps/ckb-c-std-lib/libc -I deps/ckb-c-std-lib/molecule -I c -I build \
 	-Wall -Wno-nonnull -Wno-unused-function -g
 LDFLAGS := -nostdlib -static 

--- a/Makefile.clang
+++ b/Makefile.clang
@@ -6,7 +6,7 @@ CFLAGS := \
 	-fPIC -O3 -fno-builtin-printf -fno-builtin-memcmp -nostdinc -nostdlib -fvisibility=hidden -fdata-sections -ffunction-sections \
 	-I deps/secp256k1/src -I deps/secp256k1 -I deps/ckb-c-std-lib -I deps/ckb-c-std-lib/libc -I deps/ckb-c-std-lib/molecule -I c -I build \
 	-Wall -Wno-nonnull -Wno-unused-function -g
-LDFLAGS := -nostdlib -static --gc-sections
+LDFLAGS := -nostdlib -static 
 SECP256K1_SRC_20210801 := deps/secp256k1-20210801/src/ecmult_static_pre_context.h
 
 
@@ -23,9 +23,12 @@ PROTOCOL_URL := https://raw.githubusercontent.com/nervosnetwork/ckb/${PROTOCOL_V
 MOLC := moleculec
 MOLC_VERSION := 0.7.0
 
-CLANG_FORMAT_DOCKER := kason223/clang-format@sha256:3cce35b0400a7d420ec8504558a02bdfc12fd2d10e40206f140c4545059cd95d
+BUILDER_DOCKER := xujiandong/ckb-riscv-llvm-toolchain@sha256:6409ab0d3e335c74088b54f4f73252f4b3367ae364d5c7ca7acee82135f5af4d
 
 all: build/omni_lock build/always_success
+
+all-via-docker:
+	docker run --rm -v `pwd`:/code ${BUILDER_DOCKER} bash -c "cd /code && make -f Makefile.clang all"
 
 build/always_success: c/always_success.c
 	$(CC) $(OMNI_LOCK_CFLAGS) $(LDFLAGS) -o $@ $<
@@ -37,14 +40,14 @@ build/secp256k1_data_info_20210801.h: build/dump_secp256k1_data_20210801
 
 build/dump_secp256k1_data_20210801: c/dump_secp256k1_data_20210801.c $(SECP256K1_SRC_20210801)
 	mkdir -p build
-	gcc -I deps/secp256k1-20210801/src -I deps/secp256k1-20210801 -o $@ $<
+	$(CC) -I deps/secp256k1-20210801/src -I deps/secp256k1-20210801 -o $@ $<
 
 
 $(SECP256K1_SRC_20210801):
 	cd deps/secp256k1-20210801 && \
 		./autogen.sh && \
-		CC=$(CC) LD=$(LD) ./configure --with-bignum=no --with-asm=no \
-			--enable-ecmult-static-precomputation --enable-endomorphism --enable-module-recovery && \
+		CC=$(CC) LD=$(LD) ./configure --with-asm=no \
+			--enable-ecmult-static-precomputation --enable-module-recovery && \
 		make src/ecmult_static_pre_context.h src/ecmult_static_context.h
 
 
@@ -59,7 +62,7 @@ ALL_C_SOURCE := $(wildcard c/omni_lock.c c/omni_lock_acp.h c/omni_lock_time_lock
 	c/blake2b_decl_only.h c/cobuild.h c/cobuild.c)
 
 fmt:
-	docker run --rm -v `pwd`:/code ${CLANG_FORMAT_DOCKER} bash -c "cd code && clang-format -i -style=Google $(ALL_C_SOURCE)"
+	docker run --rm -v `pwd`:/code ${BUILDER_DOCKER} bash -c "cd code && clang-format -i -style=Google $(ALL_C_SOURCE)"
 	git diff --exit-code $(ALL_C_SOURCE)
 
 mol:

--- a/tests/omni_lock_rust/tests/test_sudt_supply.rs
+++ b/tests/omni_lock_rust/tests/test_sudt_supply.rs
@@ -23,7 +23,7 @@ fn gen_info_cell_type_script() -> (Script, [u8; 32]) {
     rng.fill(&mut args[..]);
     let script = Script::new_builder()
         .code_hash(data_hash.clone())
-        .hash_type(ScriptHashType::Data.into())
+        .hash_type(ScriptHashType::Data1.into())
         .args(Bytes::from(args).pack())
         .build();
     let script_hash = script.calc_script_hash();
@@ -49,7 +49,7 @@ fn sudt_type_script(loader: &DummyDataLoader, tx: &TransactionView) -> Script {
     let data_hash = CellOutput::calc_data_hash(&SIMPLE_UDT);
     Script::new_builder()
         .code_hash(data_hash.clone())
-        .hash_type(ScriptHashType::Data.into())
+        .hash_type(ScriptHashType::Data1.into())
         .args(omni_lock_hash.as_bytes().pack())
         .build()
 }


### PR DESCRIPTION
All test cases passed with LLVM-16 tool chain.

One thing to note is that it doesn't work with -O3. We believe that secp256k1 typically uses -O2 by default, so omni_lock.c can't be compiled with -O3.